### PR TITLE
Improved error/diagnostic handling while parsing templates

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -4,8 +4,8 @@ Some code portions are held under different copyrights and/or licenses, which ca
 
 This project contains code portions written by third parties. The following projects are included in the `punktf` project in some way and include their own licenses:
 
-* The [rust](https://github.com/rust-lang/rust) compiler. Some code portions were used as inspiration, and some of them were copied. 
-    
+* The [rust](https://github.com/rust-lang/rust) compiler. Some code portions were used as inspiration, and some of them were copied.
+
     This includes:
       * Sanitization of the raw source of a template
       * Error and diagnostic handling for parsing and filling a template

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,12 @@
+Copyright for portions of project `punktf` are held by the project
+[rust](https://github.com/rust-lang/rust). Some code portions were used as
+insipration and some of them where copied. This happened in accordance with the
+MIT license, which the rust project is licensed under.
+
+This includes:
+
+- Sanitization of the raw source of a template
+- Error and diagnostic handling for parsing and filling a template
+
+All other copyright for project `punktf` is held by Michael Lohr and Jonas
+Grawe, 2021.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 serde_yaml = "0.8.17"
 thiserror = "1.0.26"
+unicode-width = "0.1.8"
 
 [profile.dev]
 opt-level = 0

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ cic: test lint
 
 # searches for things which need to be improved
 todos:
-	rg "(TODO|print|unwrap\()"
+	rg "(TODO|print(!|ln!)|unwrap\()"

--- a/src/deploy/executor.rs
+++ b/src/deploy/executor.rs
@@ -436,7 +436,7 @@ where
 			let template = Template::parse(source)
 				.with_context(|| format!("File: {}", child_source_path.display()))?;
 			let content = template
-				.fill(profile.variables.as_ref(), directory.variables.as_ref())
+				.resolve(profile.variables.as_ref(), directory.variables.as_ref())
 				.with_context(|| format!("File: {}", child_source_path.display()))?;
 
 			if !self.options.dry_run {
@@ -583,7 +583,7 @@ where
 			let template = Template::parse(source)
 				.with_context(|| format!("File: {}", file_source_path.display()))?;
 			let content = template
-				.fill(profile.variables.as_ref(), file.variables.as_ref())
+				.resolve(profile.variables.as_ref(), file.variables.as_ref())
 				.with_context(|| format!("File: {}", file_source_path.display()))?;
 
 			if !self.options.dry_run {

--- a/src/deploy/executor.rs
+++ b/src/deploy/executor.rs
@@ -7,6 +7,7 @@ use color_eyre::Result;
 
 use super::deployment::{Deployment, DeploymentBuilder};
 use crate::deploy::item::ItemStatus;
+use crate::template::source::Source;
 use crate::template::Template;
 use crate::{DeployTarget, Item, MergeMode, Profile};
 
@@ -431,7 +432,8 @@ where
 				}
 			};
 
-			let template = Template::parse(&content)
+			let source = Source::file(&child_source_path, &content);
+			let template = Template::parse(source)
 				.with_context(|| format!("File: {}", child_source_path.display()))?;
 			let content = template
 				.fill(profile.variables.as_ref(), directory.variables.as_ref())
@@ -577,7 +579,8 @@ where
 				}
 			};
 
-			let template = Template::parse(&content)
+			let source = Source::file(&file_source_path, &content);
+			let template = Template::parse(source)
 				.with_context(|| format!("File: {}", file_source_path.display()))?;
 			let content = template
 				.fill(profile.variables.as_ref(), file.variables.as_ref())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(exit_status_error)]
+#![feature(option_get_or_insert_default)]
 #![allow(dead_code)]
 
 pub mod deploy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(exit_status_error)]
 #![feature(option_get_or_insert_default)]
+#![feature(map_first_last)]
 #![allow(dead_code)]
 
 pub mod deploy;

--- a/src/template/block.rs
+++ b/src/template/block.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::span::{ByteSpan, Spanned};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -54,6 +56,12 @@ pub enum VarEnv {
 	Item,
 }
 
+impl fmt::Display for VarEnv {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(&self, f)
+	}
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VarEnvSet(pub [Option<VarEnv>; 3]);
 
@@ -89,6 +97,12 @@ impl VarEnvSet {
 impl Default for VarEnvSet {
 	fn default() -> Self {
 		Self([Some(VarEnv::Item), Some(VarEnv::Profile), None])
+	}
+}
+
+impl fmt::Display for VarEnvSet {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_list().entries(self.envs()).finish()
 	}
 }
 

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -90,6 +90,7 @@ impl Diagnositic {
 
 				let highlight = format!(
 					"{}{}",
+					// TODO: handle `\t`
 					" ".repeat(loc.character()),
 					"^".repeat(highlight_len).bright_blue().bold()
 				);

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -324,7 +324,7 @@ impl<'a> LineMap<'a> {
 			.map(|(low, _)| low)
 			.min()
 			.or_else(|| self.label_spans.iter().map(|(low, _, _)| low).min())
-			.map(|loc| *loc)
+			.copied()
 	}
 
 	pub fn line_nrs(&self) -> Vec<usize> {
@@ -332,7 +332,7 @@ impl<'a> LineMap<'a> {
 	}
 
 	pub fn line(&self, line_nr: usize) -> Option<&str> {
-		self.lines.get(&(line_nr - 1)).map(|line| *line)
+		self.lines.get(&(line_nr - 1)).copied()
 	}
 
 	pub fn line_spans_sorted(

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
+use std::collections::btree_map::{Entry, Keys};
+use std::collections::{BTreeMap, HashSet};
 
 use color_eyre::owo_colors::OwoColorize;
 
+use super::source::Location;
 use super::span::ByteSpan;
 use crate::template::source::Source;
 
@@ -50,6 +53,35 @@ impl Diagnositic {
 		//    |
 		// 28 |         out.push_str(format!(" |{}", ));
 		//    |                                 ^^
+
+		let mut fmt = DiagnositicFormatter::new(source, &self.msg);
+
+		if let Some(span) = &self.span {
+			for primary in &span.primary {
+				fmt.primary_span(primary);
+			}
+
+			for (span, label) in &span.labels {
+				fmt.label_span(span, label);
+			}
+		}
+
+		if let Some(description) = &self.description {
+			for line in description.lines() {
+				fmt.description(line);
+			}
+		}
+
+		let out = fmt.finish();
+
+		match self.level {
+			DiagnositicLevel::Error => {
+				println!("{}{} {}", "error".bright_red().bold(), ':'.bold(), out)
+			}
+			DiagnositicLevel::Warning => log::warn!("{}", out),
+		};
+
+		/*
 
 		// TODO-PM: move into separate into extra formatter
 		let mut out = String::new();
@@ -157,6 +189,7 @@ impl Diagnositic {
 			DiagnositicLevel::Error => log::error!("{}", out),
 			DiagnositicLevel::Warning => log::warn!("{}", out),
 		};
+		*/
 	}
 
 	pub fn level(&self) -> &DiagnositicLevel {
@@ -164,6 +197,7 @@ impl Diagnositic {
 	}
 }
 
+#[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnositicBuilder {
 	level: DiagnositicLevel,
@@ -220,5 +254,233 @@ impl DiagnositicBuilder {
 			span: self.span,
 			description: self.description,
 		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum SpanRef {
+	Primary(usize),
+	Label(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LineMap<'a> {
+	source: &'a Source<'a>,
+
+	// the lines are stored as line index (meaning 0 indexed)
+	lines: BTreeMap<usize, &'a str>,
+	line_spans: BTreeMap<usize, HashSet<SpanRef>>,
+	primary_spans: Vec<(Location, Location)>,
+	label_spans: Vec<(Location, Location, &'a str)>,
+}
+
+impl<'a> LineMap<'a> {
+	pub fn new(source: &'a Source<'a>) -> Self {
+		let (lines, line_spans, primary_spans, label_spans) = <_>::default();
+
+		Self {
+			source,
+			lines,
+			line_spans,
+			primary_spans,
+			label_spans,
+		}
+	}
+
+	pub fn insert_primary(&mut self, span: &ByteSpan) -> SpanRef {
+		// get index of next vacant entry
+		let span_ref = SpanRef::Primary(self.primary_spans.len());
+		self.primary_spans.push(self.locations(span));
+
+		self.intern_span(span, span_ref);
+
+		span_ref
+	}
+
+	pub fn insert_label(&mut self, span: &ByteSpan, label: &'a str) -> SpanRef {
+		// get index of next vacant entry
+		let span_ref = SpanRef::Label(self.label_spans.len());
+		let (loc_low, loc_high) = self.locations(span);
+		self.label_spans.push((loc_low, loc_high, label));
+
+		self.intern_span(span, span_ref);
+
+		span_ref
+	}
+
+	pub fn min_line_nr(&self) -> Option<usize> {
+		self.lines.first_key_value().map(|(idx, _)| idx + 1)
+	}
+
+	pub fn max_line_nr(&self) -> Option<usize> {
+		self.lines.last_key_value().map(|(idx, _)| idx + 1)
+	}
+
+	// Searches for the lowest primary location.
+	// If none is found it will search the labels for the lowest.
+	pub fn min_location(&self) -> Option<Location> {
+		self.primary_spans
+			.iter()
+			.map(|(low, _)| low)
+			.min()
+			.or_else(|| self.label_spans.iter().map(|(low, _, _)| low).min())
+			.map(|loc| *loc)
+	}
+
+	pub fn line_nrs(&self) -> Vec<usize> {
+		self.lines.keys().copied().map(|nr| nr + 1).collect()
+	}
+
+	pub fn line(&self, line_nr: usize) -> Option<&str> {
+		self.lines.get(&(line_nr - 1)).map(|line| *line)
+	}
+
+	pub fn line_spans_sorted(
+		&self,
+		line_nr: usize,
+	) -> Option<Vec<(Location, Location, Option<&'a str>)>> {
+		let refs_iter = self.line_spans.get(&(line_nr - 1))?;
+
+		let mut items = refs_iter
+			.iter()
+			.map(|&span_ref| match span_ref {
+				SpanRef::Primary(idx) => {
+					let (low, high) = self.primary_spans[idx];
+					(low, high, None)
+				}
+				SpanRef::Label(idx) => {
+					let (low, high, label) = self.label_spans[idx];
+					(low, high, Some(label))
+				}
+			})
+			.collect::<Vec<_>>();
+
+		items.sort_by_key(|item| item.0);
+
+		Some(items)
+	}
+
+	fn locations(&self, span: &ByteSpan) -> (Location, Location) {
+		(
+			self.source.get_pos_location(span.low),
+			self.source.get_pos_location(span.high),
+		)
+	}
+
+	fn intern_span(&mut self, span: &ByteSpan, span_ref: SpanRef) {
+		let line_idx_low = self.source.get_pos_line_idx(span.low);
+		let line_idx_high = self.source.get_pos_line_idx(span.high);
+
+		for line_idx in line_idx_low..=line_idx_high {
+			self.intern_line(line_idx, span_ref);
+		}
+	}
+
+	fn intern_line(&mut self, line_idx: usize, span_ref: SpanRef) {
+		if let Entry::Vacant(e) = self.lines.entry(line_idx) {
+			e.insert(self.source.get_idx_line(line_idx));
+		}
+
+		// add span ref to line where it occured
+		self.line_spans
+			.entry(line_idx)
+			.or_default()
+			.insert(span_ref);
+	}
+}
+
+pub struct DiagnositicFormatter<'a> {
+	source: &'a Source<'a>,
+	msg: &'a str,
+	descriptions: Vec<&'a str>,
+	line_map: LineMap<'a>,
+}
+
+impl<'a> DiagnositicFormatter<'a> {
+	pub fn new(source: &'a Source<'a>, msg: &'a str) -> Self {
+		let (descriptions) = <_>::default();
+
+		Self {
+			source,
+			msg,
+			descriptions,
+			line_map: LineMap::new(source),
+		}
+	}
+
+	pub fn description(&mut self, description: &'a str) -> &mut Self {
+		self.descriptions.push(description);
+		self
+	}
+
+	pub fn primary_span(&mut self, span: &ByteSpan) -> &mut Self {
+		let _ = self.line_map.insert_primary(span);
+		self
+	}
+
+	pub fn label_span(&mut self, span: &ByteSpan, label: &'a str) -> &mut Self {
+		let _ = self.line_map.insert_label(span, label);
+		self
+	}
+
+	pub fn finish(self) -> String {
+		fn style<S: AsRef<str>>(s: S) -> String {
+			s.as_ref().bright_blue().bold().to_string()
+		}
+
+		let separator = style("|");
+
+		let mut out = String::new();
+		let mut left_pad = String::from("");
+
+		out.push_str(&self.msg.bold().to_string());
+
+		// check if there are spans to format
+		if let Some(line_nr) = self.line_map.max_line_nr() {
+			left_pad = " ".repeat(line_nr.to_string().len());
+
+			// add file information
+			out.push_str(&format!(
+				"\n {}{} {}",
+				left_pad,
+				style("-->"),
+				self.source.origin(),
+			));
+			if let Some(min_loc) = self.line_map.min_location() {
+				out.push_str(&format!(":{}", min_loc.display()));
+			}
+
+			// add code lines and spans
+			out.push_str(&format!("\n {} {}", left_pad, separator));
+
+			let mut last_line_nr: Option<usize> = None;
+			for line_nr in self.line_map.line_nrs() {
+				if let Some(line) = self.line_map.line(line_nr) {
+					let line_nr_str = line_nr.to_string();
+
+					if matches!(last_line_nr, Some(lln) if (line_nr - lln) > 1) {
+						out.push_str(&format!("\n {}", style("...")));
+					}
+
+					out.push_str(&format!(
+						"\n {}{} {} {}",
+						&left_pad[line_nr_str.len()..],
+						line_nr,
+						separator,
+						line.replace('\t', "    ")
+					));
+
+					last_line_nr = Some(line_nr);
+				}
+			}
+
+			out.push_str(&format!("\n {} {}", left_pad, separator));
+		}
+
+		for description in self.descriptions {
+			out.push_str(&format!("\n {} {} {}", left_pad, style("="), description));
+		}
+
+		out
 	}
 }

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -70,11 +70,12 @@ impl Diagnositic {
 					lpad,
 					"-->".bright_blue().bold(),
 					source.origin(),
-					loc
+					loc.display()
 				));
 
 				// highlight
-				let line = source.get_pos_line(*primary.low());
+				// TODO: check if there is another way (replace allocs a new string)
+				let line = source.get_pos_line(*primary.low()).replace('\t', "    ");
 
 				let vsep = "|".bright_blue();
 				let vsep = vsep.bold();
@@ -82,16 +83,15 @@ impl Diagnositic {
 				let loc_end = source.get_pos_location(*primary.high());
 				let highlight_len = if loc.line() == loc_end.line() {
 					// on same line; get diff
-					loc_end.character() - loc.character()
+					loc_end.column() - loc.column()
 				} else {
 					// on different lines; get until end of line
-					line.len() - loc.character()
+					line.chars().count() - loc.column()
 				};
 
 				let highlight = format!(
 					"{}{}",
-					// TODO: handle `\t`
-					" ".repeat(loc.character()),
+					" ".repeat(loc.column()),
 					"^".repeat(highlight_len).bright_blue().bold()
 				);
 
@@ -113,7 +113,8 @@ impl Diagnositic {
 				let lpad = " ".repeat(loc.line().to_string().len());
 
 				// highlight
-				let line = source.get_pos_line(*span.low());
+				// TODO: check if there is another way (replace allocs a new string)
+				let line = source.get_pos_line(*span.low()).replace('\t', "    ");
 
 				let vsep = "|".bright_blue();
 				let vsep = vsep.bold();
@@ -121,15 +122,15 @@ impl Diagnositic {
 				let loc_end = source.get_pos_location(*span.high());
 				let highlight_len = if loc.line() == loc_end.line() {
 					// on same line; get diff
-					loc_end.character() - loc.character()
+					loc_end.column() - loc.column()
 				} else {
 					// on different lines; get until end of line
-					line.len() - loc.character()
+					line.len() - loc.column()
 				};
 
 				let highlight = format!(
 					"{}{} {} {}",
-					" ".repeat(loc.character()),
+					" ".repeat(loc.column()),
 					"^".repeat(highlight_len).bright_blue().bold(),
 					" <-- ".bright_blue().bold(),
 					label.bright_black()

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -92,7 +92,6 @@ impl Diagnositic {
 	}
 }
 
-#[must_use]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnositicBuilder {
 	level: DiagnositicLevel,
@@ -142,6 +141,7 @@ impl DiagnositicBuilder {
 		self
 	}
 
+	#[must_use]
 	pub fn build(self) -> Diagnositic {
 		Diagnositic {
 			level: self.level,
@@ -318,6 +318,7 @@ impl<'a> DiagnositicFormatter<'a> {
 		self
 	}
 
+	#[must_use]
 	pub fn finish(self) -> String {
 		// Rust check example:
 		// error: 1 positional argument in format string, but no arguments were given

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -1,0 +1,119 @@
+use std::borrow::Cow;
+
+use color_eyre::owo_colors::OwoColorize;
+
+use super::span::ByteSpan;
+use crate::template::source::Source;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticSpan {
+	/// A primary span is displayed with `^` bellow the spanned text.
+	primary: Vec<ByteSpan>,
+
+	/// A label is displayed as the spanned text together with the label.
+	labels: Vec<(ByteSpan, Cow<'static, str>)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagnositicLevel {
+	Error,
+	Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnositic {
+	level: DiagnositicLevel,
+	msg: Cow<'static, str>,
+	span: Option<DiagnosticSpan>,
+	description: Option<Cow<'static, str>>,
+}
+
+impl Diagnositic {
+	pub fn new<M: Into<Cow<'static, str>>, D: Into<Option<impl Into<Cow<'static, str>>>>>(
+		level: DiagnositicLevel,
+		msg: M,
+		span: Option<DiagnosticSpan>,
+		description: D,
+	) -> Self {
+		Self {
+			level,
+			msg: msg.into(),
+			span,
+			description: description.into().map(|d| d.into()),
+		}
+	}
+
+	pub fn emit(&self, source: &'_ Source<'_>) {
+		// Rust check example:
+		// error: 1 positional argument in format string, but no arguments were given
+		//   --> src/template/source.rs:28:27
+		//    |
+		// 28 |         out.push_str(format!(" |{}", ));
+		//    |                                 ^^
+
+		// TODO-PM: move into separate into extra formatter
+		let mut out = String::new();
+
+		// title
+		out.push_str(&format!("{}", self.msg.bold()));
+
+		if let Some(span) = &self.span {
+			for primary in &span.primary {
+				out.push('\n');
+
+				// location
+				let loc = source.get_pos_location(*primary.low());
+				let lpad = " ".repeat(loc.line().to_string().len());
+
+				out.push_str(&format!(
+					" {}{} {}:{}\n",
+					lpad,
+					"-->".bright_blue().bold(),
+					source.origin(),
+					loc
+				));
+
+				// highlight
+				let line = source.get_pos_line(*primary.low());
+
+				let vsep = "|".bright_blue();
+				let vsep = vsep.bold();
+
+				let loc_end = source.get_pos_location(*primary.high());
+				let highlight_len = if loc.line() == loc_end.line() {
+					// on same line; get diff
+					loc_end.character() - loc.character()
+				} else {
+					// on different lines; get until end of line
+					line.len() - loc.character()
+				};
+
+				let highlight = format!(
+					"{}{}",
+					" ".repeat(loc.character()),
+					"^".repeat(highlight_len).bright_blue().bold()
+				);
+
+				out.push_str(&format!(" {} {}\n", lpad, vsep));
+				out.push_str(&format!(
+					" {} {} {}\n",
+					loc.line().bright_blue().bold(),
+					vsep,
+					line
+				));
+				out.push_str(&format!(" {} {} {}", lpad, vsep, highlight));
+			}
+		}
+
+		// description
+		if let Some(description) = &self.description {
+			out.push('\n');
+			out.push_str(description);
+		}
+
+		match self.level {
+			DiagnositicLevel::Error => log::error!("{}", out),
+			DiagnositicLevel::Warning => log::warn!("{}", out),
+		};
+	}
+}

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -141,7 +141,6 @@ impl DiagnositicBuilder {
 		self
 	}
 
-	#[must_use]
 	pub fn build(self) -> Diagnositic {
 		Diagnositic {
 			level: self.level,
@@ -318,7 +317,6 @@ impl<'a> DiagnositicFormatter<'a> {
 		self
 	}
 
-	#[must_use]
 	pub fn finish(self) -> String {
 		// Rust check example:
 		// error: 1 positional argument in format string, but no arguments were given

--- a/src/template/diagnostic.rs
+++ b/src/template/diagnostic.rs
@@ -1,15 +1,3 @@
-//! The code for error/diagnostics handling is heavily inspiered by
-//! [rust's](https://github.com/rust-lang/rust) compiler. While some code is adpated for use with
-//! punktf, some of it is also a plain copy of it.
-//!
-//! Specifically from those files:
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs
-
 use std::borrow::Cow;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashSet};
@@ -20,6 +8,9 @@ use super::source::Location;
 use super::span::ByteSpan;
 use crate::template::source::Source;
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L474>.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct DiagnosticSpan {
 	/// A primary span is displayed with `^` bellow the spanned text.
@@ -35,6 +26,9 @@ pub enum DiagnositicLevel {
 	Warning,
 }
 
+// COPYRIGHT
+//
+// Copied from by <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_errors/src/diagnostic.rs#L15> with slight adaptations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnositic {
 	level: DiagnositicLevel,

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,3 +1,18 @@
+//! The code for error/diagnostics and source input handling is heavily inspired by
+//! [rust's](https://github.com/rust-lang/rust) compiler, which is licensed under the MIT license.
+//! While some code is adapted for use with `punktf`, some of it is also a plain copy of it. If a
+//! portion of code was copied/adapted from the Rust project there will be an explicit notices
+//! above it. For further information and the license please see the `COPYRIGHT` file in the root
+//! of this project.
+//!
+//! Specifically but not limited to:
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs>
+
 mod block;
 mod diagnostic;
 mod parse;

--- a/src/template/parse.rs
+++ b/src/template/parse.rs
@@ -372,7 +372,10 @@ impl<'a> Parser<'a> {
 	}
 }
 
-fn next_block(s: &str) -> Option<Result<(ByteSpan, Option<BlockHint>), (Option<usize>, Report)>> {
+type NextBlock = (ByteSpan, Option<BlockHint>);
+type NextBlockError = (Option<usize>, Report);
+
+fn next_block(s: &str) -> Option<Result<NextBlock, NextBlockError>> {
 	if s.is_empty() {
 		return None;
 	}

--- a/src/template/parse.rs
+++ b/src/template/parse.rs
@@ -37,10 +37,7 @@ impl<'a> Parser<'a> {
 		self.session.emit();
 		let session = self.session.try_finish()?;
 
-		Ok(Template {
-			source: session.source,
-			blocks,
-		})
+		Ok(Template { session, blocks })
 	}
 
 	fn report_diagnostic(&mut self, diagnostic: Diagnositic) {

--- a/src/template/parse/tests.rs
+++ b/src/template/parse/tests.rs
@@ -1,0 +1,556 @@
+#![cfg(test)]
+
+use color_eyre::eyre::{eyre, Result};
+use pretty_assertions::assert_eq;
+
+use super::*;
+use crate::template::block::{Block, BlockKind, If, IfExpr, IfOp, Var, VarEnv, VarEnvSet};
+use crate::template::session::Session;
+use crate::template::source::Source;
+use crate::template::span::ByteSpan;
+
+#[test]
+fn parse_single_text() -> Result<()> {
+	let content = r#"Hello World this is a text block"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(
+		block,
+		Block::new(ByteSpan::new(0usize, content.len()), BlockKind::Text)
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_comment() -> Result<()> {
+	let content = r#"{{!-- Hello World this is a comment block --}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(
+		block,
+		Block::new(ByteSpan::new(0usize, content.len()), BlockKind::Comment)
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_escaped() -> Result<()> {
+	let content = r#"{{{ Hello World this is a comment block }}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let inner = ByteSpan::new(3usize, content.len() - 3);
+	assert_eq!(&content[inner], " Hello World this is a comment block ");
+	assert_eq!(block.kind(), &BlockKind::Escaped(inner));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_var_default() -> Result<()> {
+	let content = r#"{{OS}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let name = ByteSpan::new(2usize, content.len() - 2);
+	assert_eq!(&content[name], "OS");
+	let envs = VarEnvSet([Some(VarEnv::Item), Some(VarEnv::Profile), None]);
+	assert_eq!(block.kind(), &BlockKind::Var(Var { envs, name }));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_var_env() -> Result<()> {
+	let content = r#"{{$ENV}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let name = ByteSpan::new(3usize, content.len() - 2);
+	assert_eq!(&content[name], "ENV");
+	let envs = VarEnvSet([Some(VarEnv::Environment), None, None]);
+	assert_eq!(block.kind(), &BlockKind::Var(Var { envs, name }));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_var_profile() -> Result<()> {
+	let content = r#"{{#PROFILE}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let name = ByteSpan::new(3usize, content.len() - 2);
+	assert_eq!(&content[name], "PROFILE");
+	let envs = VarEnvSet([Some(VarEnv::Profile), None, None]);
+	assert_eq!(block.kind(), &BlockKind::Var(Var { envs, name }));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_var_item() -> Result<()> {
+	let content = r#"{{&ITEM}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let name = ByteSpan::new(3usize, content.len() - 2);
+	assert_eq!(&content[name], "ITEM");
+	let envs = VarEnvSet([Some(VarEnv::Item), None, None]);
+	assert_eq!(block.kind(), &BlockKind::Var(Var { envs, name }));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_var_mixed() -> Result<()> {
+	let content = r#"{{$&#MIXED}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let name = ByteSpan::new(5usize, content.len() - 2);
+	assert_eq!(&content[name], "MIXED");
+	let envs = VarEnvSet([
+		Some(VarEnv::Environment),
+		Some(VarEnv::Item),
+		Some(VarEnv::Profile),
+	]);
+	assert_eq!(block.kind(), &BlockKind::Var(Var { envs, name }));
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_vars() -> Result<()> {
+	// duplicate variable environment
+	let content = r#"{{##OS}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.ok_or(eyre!("No block found"))?;
+
+	assert!(block.is_err());
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_if_eq() -> Result<()> {
+	let content = r#"{{@if {{OS}} == "windows"}}{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let if_span = ByteSpan::new(0usize, 27usize);
+	assert_eq!(&content[if_span], r#"{{@if {{OS}} == "windows"}}"#);
+
+	let name = ByteSpan::new(8usize, 10usize);
+	assert_eq!(&content[name], "OS");
+	let envs = VarEnvSet([Some(VarEnv::Item), Some(VarEnv::Profile), None]);
+
+	let op = IfOp::Eq;
+
+	let other = ByteSpan::new(17usize, 24usize);
+	assert_eq!(&content[other], "windows");
+
+	let end_span = ByteSpan::new(27usize, 34usize);
+	assert_eq!(&content[end_span], r#"{{@fi}}"#);
+
+	assert_eq!(
+		block.kind(),
+		&BlockKind::If(If {
+			head: (
+				if_span.span(IfExpr::Compare {
+					var: Var { envs, name },
+					op,
+					other
+				}),
+				vec![]
+			),
+			elifs: vec![],
+			els: None,
+			end: end_span
+		})
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_if_neq() -> Result<()> {
+	let content = r#"{{@if {{OS}} != "windows"}}{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let if_span = ByteSpan::new(0usize, 27usize);
+	assert_eq!(&content[if_span], r#"{{@if {{OS}} != "windows"}}"#);
+
+	let name = ByteSpan::new(8usize, 10usize);
+	assert_eq!(&content[name], "OS");
+	let envs = VarEnvSet([Some(VarEnv::Item), Some(VarEnv::Profile), None]);
+
+	let op = IfOp::NotEq;
+
+	let other = ByteSpan::new(17usize, 24usize);
+	assert_eq!(&content[other], "windows");
+
+	let end_span = ByteSpan::new(27usize, 34usize);
+	assert_eq!(&content[end_span], r#"{{@fi}}"#);
+
+	assert_eq!(
+		block.kind(),
+		&BlockKind::If(If {
+			head: (
+				if_span.span(IfExpr::Compare {
+					var: Var { envs, name },
+					op,
+					other
+				}),
+				vec![]
+			),
+			elifs: vec![],
+			els: None,
+			end: end_span
+		})
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_single_if_exists() -> Result<()> {
+	let content = r#"{{@if {{$#EXISTS}}}}{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let block = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(block.span(), &ByteSpan::new(0usize, content.len()));
+
+	let if_span = ByteSpan::new(0usize, 20usize);
+	assert_eq!(&content[if_span], r#"{{@if {{$#EXISTS}}}}"#);
+
+	let name = ByteSpan::new(10usize, 16usize);
+	assert_eq!(&content[name], "EXISTS");
+	let envs = VarEnvSet([Some(VarEnv::Environment), Some(VarEnv::Profile), None]);
+
+	let end_span = ByteSpan::new(20usize, 27usize);
+	assert_eq!(&content[end_span], r#"{{@fi}}"#);
+
+	assert_eq!(
+		block.kind(),
+		&BlockKind::If(If {
+			head: (
+				if_span.span(IfExpr::Exists {
+					var: Var { envs, name }
+				}),
+				vec![]
+			),
+			elifs: vec![],
+			els: None,
+			end: end_span
+		})
+	);
+
+	Ok(())
+}
+
+#[test]
+fn find_blocks() {
+	let content = r#"{{ Hello World }} {{{ Escaped {{ }} }} }}}
+		{{!-- Hello World {{}} {{{ asdf }}} this is a comment --}}
+		{{@if {{}} }} }}
+		"#;
+
+	println!("{}", content);
+
+	let iter = BlockIter::new(content);
+
+	// Hello World
+	// Text: SPACE
+	// Escaped
+	// Text: LF SPACES
+	// Comment
+	// Text: LF SPACES
+	// If
+	// Text: Closing LF SPACES
+	assert_eq!(iter.count(), 8);
+}
+
+#[test]
+fn find_blocks_unicode() {
+	let content = "\u{1f600}{{{ \u{1f600} }}}\u{1f600}";
+
+	let iter = BlockIter::new(content);
+
+	// Text: Smiley
+	// Escaped
+	// Text: Smiley
+	assert_eq!(iter.count(), 3);
+}
+
+#[test]
+fn parse_comment() -> Result<()> {
+	let content = r#"{{!-- Hello World this {{}} is a comment {{{{{{ }}}--}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(
+		token,
+		Block::new(ByteSpan::new(0usize, content.len()), BlockKind::Comment)
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_escaped() -> Result<()> {
+	let content = r#"{{{!-- Hello World this {{}} is a comment {{{{{{ }}--}}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(
+		token,
+		Block::new(
+			ByteSpan::new(0usize, content.len()),
+			BlockKind::Escaped(ByteSpan::new(3usize, content.len() - 3))
+		)
+	);
+
+	Ok(())
+}
+
+#[test]
+fn parse_if_cmp() -> Result<()> {
+	let content = r#"{{@if {{&OS}} == "windows" }}
+		DEMO
+		{{@elif {{&OS}} == "linux"  }}
+		LINUX
+		{{@else}}
+		ASD
+		{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(token.span, ByteSpan::new(0usize, content.len()));
+	println!("{:#?}", &token.kind);
+
+	Ok(())
+}
+
+#[test]
+fn parse_if_cmp_nested() -> Result<()> {
+	let content = r#"{{@if {{&OS}} == "windows" }}
+		{{!-- This is a nested comment --}}
+		{{{ Escaped {{}} }}}
+		{{@elif {{&OS}} == "linux"  }}
+		{{!-- Below is a nested variable --}}
+		{{ OS }}
+		{{@else}}
+		ASD
+		{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(token.span, ByteSpan::new(0usize, content.len()));
+	println!("{:#?}", &token.kind);
+
+	Ok(())
+}
+
+#[test]
+fn parse_if_exists() -> Result<()> {
+	let content = r#"{{@if {{&OS}}  }}
+		DEMO
+		ASD
+		{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(token.span, ByteSpan::new(0usize, content.len()));
+	println!("{:#?}", &token.kind);
+
+	Ok(())
+}
+
+#[test]
+fn parse_if_mixed() -> Result<()> {
+	let content = r#"{{@if {{OS}}}}
+	print("No value for variable `OS` set")
+{{@elif {{&OS}} != "windows"}}
+	print("OS is not windows")
+{{@elif {{OS}} == "windows"}}
+	{{{!-- This is a nested comment. Below it is a nested variable block. --}}}
+	print("OS is {{OS}}")
+{{@else}}
+	{{{!-- This is a nested comment. --}}}
+	print("Can never get here. {{{ {{OS}} is neither `windows` nor not `windows`. }}}")
+{{@fi}}"#;
+
+	let source = Source::anonymous(content);
+	let mut parser = Parser::new(Session::new(source));
+	let token = parser
+		.next_top_level_block()
+		.expect("Found no block")
+		.expect("Encountered a parse error");
+
+	assert_eq!(token.span, ByteSpan::new(0usize, content.len()));
+	println!("{:#?}", &token.kind);
+
+	Ok(())
+}
+
+#[test]
+fn parse_variables() -> Result<()> {
+	assert_eq!(
+		parse_var("$#&FOO_BAR", 0)?,
+		Var {
+			envs: VarEnvSet([
+				Some(VarEnv::Environment),
+				Some(VarEnv::Profile),
+				Some(VarEnv::Item)
+			]),
+			name: ByteSpan::new(3usize, 10usize),
+		}
+	);
+
+	assert_eq!(
+		parse_var("&BAZ_1", 0)?,
+		Var {
+			envs: VarEnvSet([Some(VarEnv::Item), None, None]),
+			name: ByteSpan::new(1usize, 6usize),
+		}
+	);
+
+	assert_eq!(
+		parse_var("$#&FOO_BAR", 10)?,
+		Var {
+			envs: VarEnvSet([
+				Some(VarEnv::Environment),
+				Some(VarEnv::Profile),
+				Some(VarEnv::Item)
+			]),
+			name: ByteSpan::new(13usize, 20usize),
+		}
+	);
+
+	// invalid env / var_name
+	assert!(parse_var("!FOO_BAR", 10).is_err());
+	// duplicate env
+	assert!(parse_var("&&FOO_BAR", 0).is_err());
+
+	Ok(())
+}
+
+#[test]
+fn parse_others() -> Result<()> {
+	assert_eq!(parse_other("\"BAZ_1\"", 0)?, ByteSpan::new(1usize, 6usize));
+	assert_eq!(
+		parse_other("This is a test \"Hello World How are you today\"", 0)?,
+		ByteSpan::new(16usize, 45usize)
+	);
+
+	assert!(parse_other("This is a test \"Hello World How are you today", 0).is_err());
+	assert!(parse_other("This is a test", 0).is_err());
+
+	Ok(())
+}

--- a/src/template/session.rs
+++ b/src/template/session.rs
@@ -1,0 +1,82 @@
+use std::marker::PhantomData;
+
+use color_eyre::eyre::{eyre, Result};
+
+use super::diagnostic::Diagnositic;
+use super::source::Source;
+
+pub trait SessionState {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseState {}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveState {}
+
+impl SessionState for ParseState {}
+impl SessionState for ResolveState {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session<'src, S> {
+	pub source: Source<'src>,
+	failed: bool,
+	diagnostics: Vec<Diagnositic>,
+
+	_marker: PhantomData<S>,
+}
+
+impl<'src> Session<'src, ParseState> {
+	pub fn new(source: Source<'src>) -> Self {
+		Self {
+			source,
+			failed: false,
+			diagnostics: vec![],
+
+			_marker: PhantomData,
+		}
+	}
+
+	pub fn try_finish(self) -> Result<Session<'src, ResolveState>> {
+		if self.failed {
+			Err(eyre!("Parse session has failed"))
+		} else {
+			let new = Session {
+				source: self.source,
+				failed: false,
+				diagnostics: vec![],
+
+				_marker: PhantomData,
+			};
+
+			Ok(new)
+		}
+	}
+}
+
+impl<'src> Session<'src, ResolveState> {
+	pub fn try_finish(self) -> Result<()> {
+		if self.failed {
+			Err(eyre!("Resolve session has failed"))
+		} else {
+			Ok(())
+		}
+	}
+}
+
+impl<'src, S> Session<'src, S>
+where
+	S: SessionState,
+{
+	pub fn report(&mut self, diagnostic: Diagnositic) {
+		self.diagnostics.push(diagnostic);
+	}
+
+	pub fn mark_failed(&mut self) {
+		self.failed = true;
+	}
+
+	pub fn emit(&self) {
+		for diagnostic in &self.diagnostics {
+			diagnostic.emit(&self.source);
+		}
+	}
+}

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -6,7 +6,7 @@ use super::span::{BytePos, ByteSpan, CharPos, Pos};
 
 /// Describes a location within a source file. The line is 1 indexed while
 /// the column is 0 indexed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Location {
 	line: usize,
 	column: usize,
@@ -176,18 +176,21 @@ impl<'a> Source<'a> {
 		}
 	}
 
-	pub fn get_pos_line(&self, pos: BytePos) -> &'a str {
-		let line_start_idx = self.get_pos_line_idx(pos);
+	pub fn get_idx_line(&self, idx: usize) -> &'a str {
+		let line_end_idx = self.lines.get(idx + 1);
 
-		let line_end_idx = self.lines.get(line_start_idx + 1);
+		let line_start = self.lines[idx];
 
-		let line_start = self.lines[line_start_idx];
 		// end of the line (-1 to get the last char of the line)
 		let line_end = BytePos::from_usize(
 			line_end_idx.map_or_else(|| self.content.len(), |&idx| idx.as_usize() - 1),
 		);
 
 		&self.content[ByteSpan::new(line_start, line_end)]
+	}
+
+	pub fn get_pos_line(&self, pos: BytePos) -> &'a str {
+		self.get_idx_line(self.get_pos_line_idx(pos))
 	}
 
 	pub fn origin(&self) -> &SourceOrigin<'_> {

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -3,12 +3,12 @@
 //! punktf, some of it is also a plain copy of it.
 //!
 //! Specifically from those files:
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs
-//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs>
+//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs>
 
 use std::ops::Deref;
 use std::path::Path;

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -1,3 +1,5 @@
+// TODO (cleanup): if possible split into separate files
+
 //! The code for error/diagnostics handling is heavily inspiered by
 //! [rust's](https://github.com/rust-lang/rust) compiler. While some code is adpated for use with
 //! punktf, some of it is also a plain copy of it.

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -1,0 +1,160 @@
+use std::fmt;
+use std::ops::Deref;
+use std::path::Path;
+
+use super::span::{BytePos, ByteSpan};
+
+/// Describes a location within a source file. The line is 1 indexed the
+/// character 0 indexed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Location {
+	line: usize,
+	character: usize,
+}
+
+impl Location {
+	pub fn line(&self) -> usize {
+		self.line
+	}
+
+	pub fn character(&self) -> usize {
+		self.character
+	}
+}
+
+impl fmt::Display for Location {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}:{}", self.line, self.character)
+	}
+}
+
+/// Describes where some content came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SourceOrigin<'a> {
+	File(&'a Path),
+	Anonymous,
+}
+
+impl<'a> fmt::Display for SourceOrigin<'a> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::File(path) => fmt::Display::fmt(&path.display(), f),
+			Self::Anonymous => f.write_str("anonymous"),
+		}
+	}
+}
+
+/// Holds the contents of a template file together with the origins where the
+/// content came from. Besides the origin it also holds some information used
+/// in error reporting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Source<'a> {
+	pub(crate) origin: SourceOrigin<'a>,
+	pub(crate) content: &'a str,
+	pub(crate) line_starts: Vec<usize>,
+}
+
+impl<'a> Source<'a> {
+	pub fn new(origin: SourceOrigin<'a>, content: &'a str) -> Self {
+		// find the indicies where a new line starts
+		// +1 to get the character after the `\n`
+		let line_starts = std::iter::once(0)
+			.chain(
+				content
+					.match_indices('\n')
+					.into_iter()
+					.map(|(idx, _)| idx + 1),
+			)
+			.collect();
+
+		Self {
+			origin,
+			content,
+			line_starts,
+		}
+	}
+
+	pub fn anonymous(content: &'a str) -> Self {
+		Self::new(SourceOrigin::Anonymous, content)
+	}
+
+	pub fn file(path: &'a Path, content: &'a str) -> Self {
+		Self::new(SourceOrigin::File(path), content)
+	}
+
+	pub fn get_pos_line_idx(&self, pos: BytePos) -> usize {
+		match self.line_starts.binary_search(&pos.as_usize()) {
+			Ok(idx) => idx,
+			Err(idx) => idx - 1,
+		}
+	}
+
+	pub fn get_pos_location(&self, pos: BytePos) -> Location {
+		let line_idx = self.get_pos_line_idx(pos);
+		let line_start = self.line_starts[line_idx];
+
+		Location {
+			line: line_idx + 1,
+			character: (pos.as_usize() - line_start),
+		}
+	}
+
+	pub fn get_pos_line(&self, pos: BytePos) -> &'a str {
+		let line_start_idx = self.get_pos_line_idx(pos);
+
+		let line_end_idx = self.line_starts.get(line_start_idx + 1);
+
+		let line_start = BytePos::from_usize(self.line_starts[line_start_idx]);
+		// end of the line (-1 to get the last char of the line)
+		let line_end =
+			BytePos::from_usize(line_end_idx.map_or_else(|| self.content.len(), |&idx| idx - 1));
+
+		&self.content[ByteSpan::new(line_start, line_end)]
+	}
+
+	pub fn origin(&self) -> &SourceOrigin<'_> {
+		&self.origin
+	}
+
+	pub fn content(&self) -> &str {
+		self.content
+	}
+}
+
+impl Deref for Source<'_> {
+	type Target = str;
+
+	fn deref(&self) -> &Self::Target {
+		self.content
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn lines() {
+		let content = r#"Hello
+World
+Foo
+Bar"#;
+
+		let src = Source::anonymous(content);
+
+		assert_eq!(
+			src.get_pos_location(BytePos::new(0)),
+			Location {
+				line: 1,
+				character: 0
+			}
+		);
+		assert_eq!(
+			src.get_pos_location(BytePos::new(6)),
+			Location {
+				line: 2,
+				character: 0
+			}
+		);
+	}
+}

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -1,3 +1,15 @@
+//! The code for error/diagnostics handling is heavily inspiered by
+//! [rust's](https://github.com/rust-lang/rust) compiler. While some code is adpated for use with
+//! punktf, some of it is also a plain copy of it.
+//!
+//! Specifically from those files:
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs
+//! - https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs
+
 use std::ops::Deref;
 use std::path::Path;
 use std::{fmt, vec};

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -1,15 +1,15 @@
-use std::fmt;
 use std::ops::Deref;
 use std::path::Path;
+use std::{fmt, vec};
 
-use super::span::{BytePos, ByteSpan};
+use super::span::{BytePos, ByteSpan, CharPos, Pos};
 
-/// Describes a location within a source file. The line is 1 indexed the
-/// character 0 indexed.
+/// Describes a location within a source file. The line is 1 indexed while
+/// the column is 0 indexed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Location {
 	line: usize,
-	character: usize,
+	column: usize,
 }
 
 impl Location {
@@ -17,14 +17,13 @@ impl Location {
 		self.line
 	}
 
-	pub fn character(&self) -> usize {
-		self.character
+	pub fn column(&self) -> usize {
+		self.column
 	}
-}
 
-impl fmt::Display for Location {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}:{}", self.line, self.character)
+	// displays column as 1 indexed
+	pub fn display(&self) -> String {
+		format!("{}:{}", self.line, self.column + 1)
 	}
 }
 
@@ -44,33 +43,86 @@ impl<'a> fmt::Display for SourceOrigin<'a> {
 	}
 }
 
-/// Holds the contents of a template file together with the origins where the
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MultiByteChar {
+	pos: BytePos,
+	bytes: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpecialWidthChar {
+	ZeroWidth(BytePos),
+	/// A full width char
+	Wide(BytePos),
+	/// Tab byte `\t` 0x09
+	Tab(BytePos),
+}
+
+impl SpecialWidthChar {
+	pub fn width(&self) -> usize {
+		match self {
+			Self::ZeroWidth(_) => 0,
+			Self::Wide(_) => 2,
+			Self::Tab(_) => 4,
+		}
+	}
+
+	pub fn pos(&self) -> &BytePos {
+		match self {
+			Self::ZeroWidth(p) | Self::Wide(p) | Self::Tab(p) => p,
+		}
+	}
+}
+
+fn analyze_source(content: &'_ str) -> (Vec<BytePos>, Vec<SpecialWidthChar>, Vec<MultiByteChar>) {
+	// start first line at index 0
+	let mut lines = vec![BytePos::new(0)];
+	let mut special_width_chars = Vec::new();
+	let multi_byte_chars = Vec::new();
+
+	for pos in 0..content.len() {
+		let byte = content.as_bytes()[pos];
+
+		// all chars between 0-31 are ascii control characters
+		if byte < 32 {
+			match byte {
+				b'\n' => lines.push(BytePos::from_usize(pos + 1)),
+				b'\t' => special_width_chars.push(SpecialWidthChar::Tab(BytePos::from_usize(pos))),
+				_ => {
+					special_width_chars.push(SpecialWidthChar::ZeroWidth(BytePos::from_usize(pos)))
+				}
+			}
+		} else if byte > 127 {
+			// bigger than `DEL`, could be multi-byte char
+			// TODO
+		}
+	}
+
+	(lines, special_width_chars, multi_byte_chars)
+}
+
+/// Holds the contents of a template file together with the origins where the
 /// content came from. Besides the origin it also holds some information used
 /// in error reporting.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Source<'a> {
 	pub(crate) origin: SourceOrigin<'a>,
 	pub(crate) content: &'a str,
-	pub(crate) line_starts: Vec<usize>,
+	pub(crate) lines: Vec<BytePos>,
+	pub(crate) special_width_chars: Vec<SpecialWidthChar>,
+	pub(crate) multi_byte_chars: Vec<MultiByteChar>,
 }
 
 impl<'a> Source<'a> {
 	pub fn new(origin: SourceOrigin<'a>, content: &'a str) -> Self {
-		// find the indicies where a new line starts
-		// +1 to get the character after the `\n`
-		let line_starts = std::iter::once(0)
-			.chain(
-				content
-					.match_indices('\n')
-					.into_iter()
-					.map(|(idx, _)| idx + 1),
-			)
-			.collect();
+		let (lines, special_width_chars, multi_byte_chars) = analyze_source(content);
 
 		Self {
 			origin,
 			content,
-			line_starts,
+			lines,
+			special_width_chars,
+			multi_byte_chars,
 		}
 	}
 
@@ -82,8 +134,30 @@ impl<'a> Source<'a> {
 		Self::new(SourceOrigin::File(path), content)
 	}
 
+	pub fn get_charpos(&self, pos: BytePos) -> CharPos {
+		let mut offset = 0;
+		let mut count = 0;
+
+		for swc in &self.special_width_chars {
+			if swc.pos() < &pos {
+				offset += swc.width();
+				count += 1;
+			} else {
+				// as the pos's are sorted we can abort after the first bigger
+				// pos
+				break;
+			}
+		}
+
+		let cpos = CharPos::from_usize((pos.as_usize() - count) + offset);
+
+		log::trace!("Traslating pos: {} > {}", pos, cpos,);
+
+		cpos
+	}
+
 	pub fn get_pos_line_idx(&self, pos: BytePos) -> usize {
-		match self.line_starts.binary_search(&pos.as_usize()) {
+		match self.lines.binary_search(&pos) {
 			Ok(idx) => idx,
 			Err(idx) => idx - 1,
 		}
@@ -91,23 +165,27 @@ impl<'a> Source<'a> {
 
 	pub fn get_pos_location(&self, pos: BytePos) -> Location {
 		let line_idx = self.get_pos_line_idx(pos);
-		let line_start = self.line_starts[line_idx];
+		let line_start = self.lines[line_idx];
+
+		let pos_cpos = self.get_charpos(pos);
+		let line_start_cpos = self.get_charpos(line_start);
 
 		Location {
 			line: line_idx + 1,
-			character: (pos.as_usize() - line_start),
+			column: (pos_cpos.as_usize() - line_start_cpos.as_usize()),
 		}
 	}
 
 	pub fn get_pos_line(&self, pos: BytePos) -> &'a str {
 		let line_start_idx = self.get_pos_line_idx(pos);
 
-		let line_end_idx = self.line_starts.get(line_start_idx + 1);
+		let line_end_idx = self.lines.get(line_start_idx + 1);
 
-		let line_start = BytePos::from_usize(self.line_starts[line_start_idx]);
+		let line_start = self.lines[line_start_idx];
 		// end of the line (-1 to get the last char of the line)
-		let line_end =
-			BytePos::from_usize(line_end_idx.map_or_else(|| self.content.len(), |&idx| idx - 1));
+		let line_end = BytePos::from_usize(
+			line_end_idx.map_or_else(|| self.content.len(), |&idx| idx.as_usize() - 1),
+		);
 
 		&self.content[ByteSpan::new(line_start, line_end)]
 	}
@@ -134,7 +212,7 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn lines() {
+	fn location_lines() {
 		let content = r#"Hello
 World
 Foo
@@ -144,17 +222,28 @@ Bar"#;
 
 		assert_eq!(
 			src.get_pos_location(BytePos::new(0)),
-			Location {
-				line: 1,
-				character: 0
-			}
+			Location { line: 1, column: 0 }
 		);
 		assert_eq!(
 			src.get_pos_location(BytePos::new(6)),
-			Location {
-				line: 2,
-				character: 0
-			}
+			Location { line: 2, column: 0 }
+		);
+	}
+
+	#[test]
+	fn location_special() {
+		let content = "\tA\r\n\t\tHello";
+
+		let src = Source::anonymous(content);
+
+		assert_eq!(
+			src.get_pos_location(BytePos::new(1)),
+			Location { line: 1, column: 4 }
+		);
+
+		assert_eq!(
+			src.get_pos_location(BytePos::new(6)),
+			Location { line: 2, column: 8 }
 		);
 	}
 }

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -1,17 +1,5 @@
 // TODO (cleanup): if possible split into separate files
 
-//! The code for error/diagnostics handling is heavily inspiered by
-//! [rust's](https://github.com/rust-lang/rust) compiler. While some code is adpated for use with
-//! punktf, some of it is also a plain copy of it.
-//!
-//! Specifically from those files:
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/lib.rs>
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/analyze_source_file.rs>
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_parse/src/parser/diagnostics.rs>
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic.rs>
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/diagnostic_builder.rs>
-//! - <https://github.com/rust-lang/rust/blob/master/compiler/rustc_errors/src/emitter.rs>
-
 use std::ops::Deref;
 use std::path::Path;
 use std::{fmt, vec};
@@ -43,7 +31,11 @@ impl Location {
 	}
 }
 
+// COPYRIGHT
+//
+// Inspired by <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L273>.
 /// Describes where some content came from.
+///
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SourceOrigin<'a> {
 	File(&'a Path),
@@ -59,6 +51,9 @@ impl<'a> fmt::Display for SourceOrigin<'a> {
 	}
 }
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L1059>.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MultiByteChar {
 	pos: BytePos,
@@ -75,10 +70,14 @@ impl MultiByteChar {
 	}
 }
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L1068>.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SpecialWidthChar {
+	/// A zero width character. These are mostly ASCII control characters.
 	ZeroWidth(BytePos),
-	/// A full width char
+	/// A full width char.
 	Wide(BytePos),
 	/// Tab byte `\t` 0x09
 	Tab(BytePos),
@@ -109,6 +108,9 @@ impl SpecialWidthChar {
 	}
 }
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/analyze_source_file.rs#L207> with slight adaptations.
 fn analyze_source(content: &'_ str) -> (Vec<BytePos>, Vec<SpecialWidthChar>, Vec<MultiByteChar>) {
 	// start first line at index 0
 	let mut i = 0;
@@ -156,6 +158,9 @@ fn analyze_source(content: &'_ str) -> (Vec<BytePos>, Vec<SpecialWidthChar>, Vec
 	(lines, special_width_chars, multi_byte_chars)
 }
 
+// COPYRIGHT
+//
+// Inspired by <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L1246>.
 /// Holds the contents of a template file together with the origins where the
 /// content came from. Besides the origin it also holds some information used
 /// in error reporting.
@@ -217,7 +222,7 @@ impl<'a> Source<'a> {
 
 		let cpos = CharPos::from_usize((pos.as_usize() + offset) - count);
 
-		log::trace!("Traslating pos: {} > {}", pos, cpos,);
+		log::trace!("Translating pos: {} > {}", pos, cpos,);
 
 		cpos
 	}

--- a/src/template/span.rs
+++ b/src/template/span.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 use std::ops::{Deref, Index};
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L1768>.
 /// A general position which allows convertion from and to [`usize`] and [`u32`].
 pub trait Pos {
 	fn from_usize(value: usize) -> Self;
@@ -9,6 +12,9 @@ pub trait Pos {
 	fn as_u32(&self) -> u32;
 }
 
+// COPYRIGHT
+//
+// Copied from <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L1775> with slight adaptations.
 macro_rules! pos {
     (
         $(
@@ -75,6 +81,9 @@ pos! {
 	pub struct CharPos(pub u32);
 }
 
+// COPYRIGHT
+//
+// Inspired by <https://github.com/rust-lang/rust/blob/362e0f55eb1f36d279e5c4a58fb0fe5f9a2c579d/compiler/rustc_span/src/lib.rs#L419>.
 /// A span with a start position ([low](`ByteSpan::low`)) and an end position ([high](`ByteSpan::high`)).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ByteSpan {

--- a/src/template/span.rs
+++ b/src/template/span.rs
@@ -1,71 +1,75 @@
 use std::fmt;
-use std::ops::{Deref, DerefMut, Index};
+use std::ops::{Deref, Index};
 
-type BytePosType = u32;
+pub trait Pos {
+	fn from_usize(value: usize) -> Self;
+	fn from_u32(value: u32) -> Self;
+	fn as_usize(&self) -> usize;
+	fn as_u32(&self) -> u32;
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BytePos(pub BytePosType);
+macro_rules! pos {
+    (
+        $(
+            $(#[$attr:meta])*
+            $vis:vis struct $ident:ident($inner_vis:vis $inner_ty:ty);
+        )*
+    ) => {
+        $(
+            $(#[$attr])*
+            $vis struct $ident($inner_vis $inner_ty);
 
-impl BytePos {
-	pub fn new(value: BytePosType) -> Self {
-		Self(value)
-	}
+			impl $ident {
+				pub fn new(value: $inner_ty) -> Self {
+					Self(value)
+				}
+			}
 
-	pub fn from_usize(value: usize) -> Self {
-		Self(value as BytePosType)
-	}
+			impl Pos for $ident {
+				fn from_usize(value: usize) -> Self {
+					Self(value as $inner_ty)
+				}
 
-	pub fn as_usize(&self) -> usize {
-		self.0 as usize
-	}
+				fn from_u32(value: u32) -> Self {
+					Self(value as $inner_ty)
+				}
 
-	pub fn into_inner(self) -> BytePosType {
-		self.0
+				fn as_usize(&self) -> usize {
+					self.0 as usize
+				}
+
+				fn as_u32(&self) -> u32 {
+					self.0 as u32
+				}
+			}
+
+			impl ::std::convert::From<usize> for $ident {
+				fn from(value: usize) -> Self {
+					Self::from_usize(value)
+				}
+			}
+
+			impl ::std::convert::From<u32> for $ident {
+				fn from(value: u32) -> Self {
+					Self::from_u32(value)
+				}
+			}
+
+			impl ::std::fmt::Display for $ident {
+				fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+					::std::fmt::Display::fmt(&self.0, f)
+				}
+			}
+		)*
 	}
 }
 
-impl fmt::Display for BytePos {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		fmt::Display::fmt(&self.0, f)
-	}
-}
+pos! {
+	#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	pub struct BytePos(pub u32);
 
-impl From<usize> for BytePos {
-	fn from(value: usize) -> Self {
-		BytePos::from_usize(value)
-	}
-}
-
-impl From<BytePosType> for BytePos {
-	fn from(value: BytePosType) -> Self {
-		Self(value)
-	}
-}
-
-impl From<BytePos> for usize {
-	fn from(value: BytePos) -> Self {
-		value.as_usize()
-	}
-}
-
-impl From<BytePos> for BytePosType {
-	fn from(value: BytePos) -> Self {
-		value.0
-	}
-}
-
-impl Deref for BytePos {
-	type Target = BytePosType;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl DerefMut for BytePos {
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
+	#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	pub struct CharPos(pub u32);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -115,7 +119,7 @@ impl ByteSpan {
 		let amount = amount.into();
 
 		let mut copy = *self;
-		copy.low.0 = (copy.low.0 as i32 + amount) as BytePosType;
+		copy.low.0 = (copy.low.0 as i32 + amount) as u32;
 
 		copy
 	}
@@ -124,7 +128,7 @@ impl ByteSpan {
 		let amount = amount.into();
 
 		let mut copy = *self;
-		copy.high.0 = (copy.high.0 as i32 + amount) as BytePosType;
+		copy.high.0 = (copy.high.0 as i32 + amount) as u32;
 
 		copy
 	}
@@ -133,8 +137,8 @@ impl ByteSpan {
 		let amount = amount.into();
 
 		let mut copy = *self;
-		copy.low.0 = (copy.low.0 as i32 + amount) as BytePosType;
-		copy.high.0 = (copy.high.0 as i32 + amount) as BytePosType;
+		copy.low.0 = (copy.low.0 as i32 + amount) as u32;
+		copy.high.0 = (copy.high.0 as i32 + amount) as u32;
 
 		copy
 	}

--- a/src/template/span.rs
+++ b/src/template/span.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::ops::{Deref, Index};
 
+/// A general position which allows convertion from and to [`usize`] and [`u32`].
 pub trait Pos {
 	fn from_usize(value: usize) -> Self;
 	fn from_u32(value: u32) -> Self;
@@ -65,13 +66,16 @@ macro_rules! pos {
 }
 
 pos! {
+	/// A position of a byte.
 	#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	pub struct BytePos(pub u32);
 
+	/// A position of a character.
 	#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	pub struct CharPos(pub u32);
 }
 
+/// A span with a start position ([low](`ByteSpan::low`)) and an end position ([high](`ByteSpan::high`)).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ByteSpan {
 	pub low: BytePos,


### PR DESCRIPTION
The layout of the error/diagnostic messages is heavily inspired by [rust's](https://github.com/rust-lang) way of doing it as i find them to be very clear and concise messages.

# Example

```text
error: failed to parse block
       --> /home/mtx/.config/punktf/items/test.txt:12:13
        |
      9 |         {{@else}}
        |         --------- while parsing this `else` block
     ...
     12 |             {{!-- This is a nested comment.
        |             ^^^^^
        |
        = Found opening for a comment block but no closing
```