### PR TITLE
Content Transformers

### DIFF
--- a/crates/punktf-lib/src/deploy/executor.rs
+++ b/crates/punktf-lib/src/deploy/executor.rs
@@ -789,9 +789,9 @@ where
 
 			// Apply transformers.
 			// Order:
-			//   - Dotfile transformers
-			//   - Then profile transformers
-			for transformer in exec_transformers.iter().chain(profile.transformers()) {
+			//   - Profile transformers
+			//   - then dotfile transformers
+			for transformer in profile.transformers().chain(exec_transformers.iter()) {
 				content = match transformer.transform(content) {
 					Ok(content) => content,
 					Err(err) => {

--- a/crates/punktf-lib/src/deploy/executor.rs
+++ b/crates/punktf-lib/src/deploy/executor.rs
@@ -789,8 +789,8 @@ where
 
 			// Apply transformers.
 			// Order:
-			//   - Profile transformers
-			//   - then dotfile transformers
+			//   - Transformers which are specified in the profile root
+			//   - Transformers which are specified on a specific dotfile of a profile
 			for transformer in profile.transformers().chain(exec_transformers.iter()) {
 				content = match transformer.transform(content) {
 					Ok(content) => content,

--- a/crates/punktf-lib/src/deploy/executor.rs
+++ b/crates/punktf-lib/src/deploy/executor.rs
@@ -17,7 +17,7 @@ use crate::{Dotfile, MergeMode, Priority, PunktfSource};
 /// An enum to be generic over both a "real" dotfile and a child of a directory
 /// dotfile.
 enum ExecutorDotfile<'a> {
-	/// A "real" dotile.
+	/// A "real" dotfile.
 	File {
 		/// The dotfile.
 		dotfile: Dotfile,

--- a/crates/punktf-lib/src/deploy/executor.rs
+++ b/crates/punktf-lib/src/deploy/executor.rs
@@ -679,7 +679,7 @@ where
 		// Fast Path.
 		if !exec_dotfile.is_template()
 			&& exec_dotfile.transformers().is_empty()
-			&& profile.transformers_origin().is_empty()
+			&& profile.transformers_len() == 0
 		{
 			// File is no template and no transformers are specified. This means
 			// we can take the fast path of just copying via the filesystem.

--- a/crates/punktf-lib/src/deploy/executor.rs
+++ b/crates/punktf-lib/src/deploy/executor.rs
@@ -10,6 +10,7 @@ use crate::deploy::dotfile::DotfileStatus;
 use crate::profile::LayeredProfile;
 use crate::template::source::Source;
 use crate::template::Template;
+use crate::transform::{ContentTransformer, Transform as _};
 use crate::variables::Variables;
 use crate::{Dotfile, MergeMode, Priority, PunktfSource};
 
@@ -115,6 +116,16 @@ impl<'a> ExecutorDotfile<'a> {
 		match self {
 			Self::File { dotfile, .. } => dotfile.variables.as_ref(),
 			Self::Child { parent, .. } => parent.variables.as_ref(),
+		}
+	}
+
+	/// Returns the [dotfile transformers][`crate::Dotfile::transformers`].
+	///
+	/// If it is a child, the value of the directory dotfile is used.
+	fn transformers(&self) -> &[ContentTransformer] {
+		match self {
+			Self::File { dotfile, .. } => &dotfile.transformers,
+			Self::Child { parent, .. } => &parent.transformers,
 		}
 	}
 
@@ -665,83 +676,14 @@ where
 			}
 		}
 
-		if exec_dotfile.is_template() {
-			let content = match std::fs::read_to_string(&exec_dotfile.source_path()) {
-				Ok(content) => content,
-				Err(err) => {
-					log::info!(
-						"{}: Failed to read dotfile source content",
-						exec_dotfile.path().display()
-					);
+		// Fast Path.
+		if !exec_dotfile.is_template()
+			&& exec_dotfile.transformers().is_empty()
+			&& profile.transformers_origin().is_empty()
+		{
+			// File is no template and no transformers are specified. This means
+			// we can take the fast path of just copying via the filesystem.
 
-					exec_dotfile.add_to_builder(
-						builder,
-						DotfileStatus::failed(format!(
-							"Failed to read dotfile source content: {}",
-							err
-						)),
-					);
-
-					return Ok(());
-				}
-			};
-
-			let source = Source::file(exec_dotfile.source_path(), &content);
-
-			let template = match Template::parse(source)
-				.with_context(|| format!("File: {}", exec_dotfile.source_path().display()))
-			{
-				Ok(template) => template,
-				Err(err) => {
-					log::error!(
-						"{}: Failed to parse template",
-						exec_dotfile.path().display()
-					);
-
-					exec_dotfile.add_to_builder(
-						builder,
-						DotfileStatus::failed(format!("Failed to parse template: {}", err)),
-					);
-
-					return Ok(());
-				}
-			};
-
-			let content = match template
-				.resolve(Some(profile.variables()), exec_dotfile.variables())
-				.with_context(|| format!("File: {}", exec_dotfile.source_path().display()))
-			{
-				Ok(template) => template,
-				Err(err) => {
-					log::error!(
-						"{}: Failed to resolve template",
-						exec_dotfile.path().display()
-					);
-
-					exec_dotfile.add_to_builder(
-						builder,
-						DotfileStatus::failed(format!("Failed to resolve template: {}", err)),
-					);
-
-					return Ok(());
-				}
-			};
-
-			log::trace!("{}: Resolved:\n{}", exec_dotfile.path().display(), content);
-
-			if !self.options.dry_run {
-				if let Err(err) = std::fs::write(&exec_dotfile.deploy_path(), content.as_bytes()) {
-					log::info!("{}: Failed to write content", exec_dotfile.path().display());
-
-					exec_dotfile.add_to_builder(
-						builder,
-						DotfileStatus::failed(format!("Failed to write content: {}", err)),
-					);
-
-					return Ok(());
-				}
-			}
-		} else {
 			// Allowed for readability
 			#[allow(clippy::collapsible_else_if)]
 			if !self.options.dry_run {
@@ -753,6 +695,133 @@ where
 					exec_dotfile.add_to_builder(
 						builder,
 						DotfileStatus::failed(format!("Failed to copy: {}", err)),
+					);
+
+					return Ok(());
+				}
+			}
+		} else {
+			let mut content = if exec_dotfile.is_template() {
+				let content = match std::fs::read_to_string(&exec_dotfile.source_path()) {
+					Ok(content) => content,
+					Err(err) => {
+						log::info!(
+							"{}: Failed to read dotfile source content",
+							exec_dotfile.path().display()
+						);
+
+						exec_dotfile.add_to_builder(
+							builder,
+							DotfileStatus::failed(format!(
+								"Failed to read dotfile source content: {}",
+								err
+							)),
+						);
+
+						return Ok(());
+					}
+				};
+
+				let source = Source::file(exec_dotfile.source_path(), &content);
+
+				let template = match Template::parse(source)
+					.with_context(|| format!("File: {}", exec_dotfile.source_path().display()))
+				{
+					Ok(template) => template,
+					Err(err) => {
+						log::error!(
+							"{}: Failed to parse template",
+							exec_dotfile.path().display()
+						);
+
+						exec_dotfile.add_to_builder(
+							builder,
+							DotfileStatus::failed(format!("Failed to parse template: {}", err)),
+						);
+
+						return Ok(());
+					}
+				};
+
+				let content = match template
+					.resolve(Some(profile.variables()), exec_dotfile.variables())
+					.with_context(|| format!("File: {}", exec_dotfile.source_path().display()))
+				{
+					Ok(template) => template,
+					Err(err) => {
+						log::error!(
+							"{}: Failed to resolve template",
+							exec_dotfile.path().display()
+						);
+
+						exec_dotfile.add_to_builder(
+							builder,
+							DotfileStatus::failed(format!("Failed to resolve template: {}", err)),
+						);
+
+						return Ok(());
+					}
+				};
+
+				log::trace!("{}: Resolved:\n{}", exec_dotfile.path().display(), content);
+
+				content
+			} else {
+				// We have some transformers to run on the content and thus can not straight copy the
+				// contents.
+				match std::fs::read_to_string(&exec_dotfile.source_path()) {
+					Ok(content) => content,
+					Err(err) => {
+						log::info!("{}: Failed to copy dotfile", exec_dotfile.path().display());
+
+						exec_dotfile.add_to_builder(
+							builder,
+							DotfileStatus::failed(format!("Failed to copy: {}", err)),
+						);
+
+						return Ok(());
+					}
+				}
+			};
+
+			// Copy so we exec_dotfile is not referenced by this in case an error occurs.
+			let exec_transformers: Vec<_> = exec_dotfile.transformers().iter().copied().collect();
+
+			// Apply transformers.
+			// Order:
+			//   - Dotfile transformers
+			//   - Then profile transformers
+			for transformer in exec_transformers.iter().chain(profile.transformers()) {
+				content = match transformer.transform(content) {
+					Ok(content) => content,
+					Err(err) => {
+						log::info!(
+							"{}: Failed to apply content transformer `{}`: `{}`",
+							exec_dotfile.path().display(),
+							transformer,
+							err
+						);
+
+						exec_dotfile.add_to_builder(
+							builder,
+							DotfileStatus::failed(format!(
+								"Failed to apply content transformer `{}`: `{}`",
+								transformer, err
+							)),
+						);
+
+						return Ok(());
+					}
+				};
+			}
+
+			if !self.options.dry_run {
+				if let Err(err) = std::fs::write(&exec_dotfile.deploy_path(), content.as_bytes()) {
+					log::info!("{}: Failed to write content", exec_dotfile.path().display());
+
+					exec_dotfile.add_to_builder(
+						builder,
+						DotfileStatus::failed(format!("Failed to write content: {}", err)),
 					);
 
 					return Ok(());

--- a/crates/punktf-lib/src/lib.rs
+++ b/crates/punktf-lib/src/lib.rs
@@ -50,6 +50,7 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::Context;
 use serde::{Deserialize, Serialize};
+use transform::ContentTransformer;
 use variables::Variables;
 
 /// This struct represents the source directory used by `punktf`. The source
@@ -226,6 +227,12 @@ pub struct Dotfile {
 	/// [`profile::Profile::variables`].
 	#[serde(skip_serializing_if = "Option::is_none", default)]
 	variables: Option<Variables>,
+
+	/// Content transform defined for the dotfile. These variables will take
+	/// precendence over the ones defined in
+	/// [`profile::Profile::transformers`].
+	#[serde(skip_serializing_if = "Vec::is_empty", default)]
+	pub transformers: Vec<ContentTransformer>,
 
 	/// Merge operation for already existing dotfiles with the same or higher
 	/// priority.

--- a/crates/punktf-lib/src/lib.rs
+++ b/crates/punktf-lib/src/lib.rs
@@ -43,6 +43,7 @@ pub mod deploy;
 pub mod hook;
 pub mod profile;
 pub mod template;
+pub mod transform;
 pub mod variables;
 
 use std::path::{Path, PathBuf};

--- a/crates/punktf-lib/src/profile.rs
+++ b/crates/punktf-lib/src/profile.rs
@@ -196,6 +196,12 @@ impl LayeredProfile {
 		&self.variables
 	}
 
+	/// Returns all collected content transformer for the profile together with
+	/// the index where they came from.
+	pub fn transformers_origin(&self) -> &[(usize, ContentTransformer)] {
+		&self.transformers
+	}
+
 	/// Returns all collected content transformer for the profile.
 	pub fn transformers(&self) -> impl Iterator<Item = &ContentTransformer> {
 		self.transformers.iter().map(|(_, transformer)| transformer)

--- a/crates/punktf-lib/src/profile.rs
+++ b/crates/punktf-lib/src/profile.rs
@@ -196,10 +196,9 @@ impl LayeredProfile {
 		&self.variables
 	}
 
-	/// Returns all collected content transformer for the profile together with
-	/// the index where they came from.
-	pub fn transformers_origin(&self) -> &[(usize, ContentTransformer)] {
-		&self.transformers
+	/// Returns all the count of collected transformers for the profile.
+	pub fn transformers_len(&self) -> usize {
+		self.transformers.len()
 	}
 
 	/// Returns all collected content transformer for the profile.

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -1,7 +1,7 @@
-//! Transforms run once for each defined dotile during the deploy process.
+//! Transforms run once for each defined dotfile during the deploy process.
 //!
-//! They can either be specified for a whole profile, in which case each dotile
-//! is transformed by them or they can be attached to a specific dotile.
+//! They can either be specified for a whole profile, in which case each dotfile
+//! is transformed by them or they can be attached to a specific dotfile.
 //!
 //! The transformation takes place after the template resolving and takes the
 //! contents in a textual representation. After processing the text a new text
@@ -11,7 +11,7 @@ use std::fmt;
 
 use color_eyre::Result;
 
-/// A transform takes the contents of a dotile, processes it and returns a new
+/// A transform takes the contents of a dotfile, processes it and returns a new
 /// version of the content.
 ///
 /// The dotfile is either the text of a resolved template or a non-template
@@ -54,10 +54,10 @@ impl fmt::Display for ContentTransformer {
 /// style (`\n`) or windows style (`\r\b`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum LineTerminator {
-	/// Replaces all occurences of `\r\n` with `\n` (unix style).
+	/// Replaces all occurrences of `\r\n` with `\n` (unix style).
 	Lf,
 
-	/// Replaces all occurences of `\n` with `\r\n` (windows style).
+	/// Replaces all occurrences of `\n` with `\r\n` (windows style).
 	Crlf,
 }
 

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -1,5 +1,7 @@
 //! TODO
 
+use std::fmt;
+
 use color_eyre::Result;
 
 /// TODO
@@ -13,6 +15,20 @@ pub trait Transform {
 pub enum ContentTransformer {
 	/// TODO
 	LineTerminator(LineTerminator),
+}
+
+impl Transform for ContentTransformer {
+	fn transform(&self, content: String) -> Result<String> {
+		match self {
+			Self::LineTerminator(lt) => lt.transform(content),
+		}
+	}
+}
+
+impl fmt::Display for ContentTransformer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+		fmt::Display::fmt(&self, f)
+	}
 }
 
 /// TODO
@@ -61,6 +77,12 @@ impl Transform for LineTerminator {
 				Ok(content)
 			}
 		}
+	}
+}
+
+impl fmt::Display for LineTerminator {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+		fmt::Debug::fmt(&self, f)
 	}
 }
 

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -4,16 +4,28 @@ use std::fmt;
 
 use color_eyre::Result;
 
-/// TODO
+/// A transform takes the contents of a dotile, processes it and returns a new
+/// version of the content.
+///
+/// The dotfile is either the text of a resolved template or a non-template
+/// dotfile.
 pub trait Transform {
-	/// TODO
+	/// Takes a string as input, processes it and returns a new version of it.
+	///
+	/// # Errors
+	///
+	/// If any error occurs during the processing it can be returned.
 	fn transform(&self, content: String) -> Result<String>;
 }
 
-/// TODO
+/// List of all available [`Transform`]s.
+///
+/// These can be added to a [`Profile`](`crate::profile::Profile`) or a
+/// [`Dotfile`](`crate::Dotfile`) to modify the text content.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ContentTransformer {
-	/// TODO
+	/// Transformer which replaces line termination characters with either unix
+	/// style (`\n`) or windows style (`\r\b`).
 	LineTerminator(LineTerminator),
 }
 
@@ -31,13 +43,14 @@ impl fmt::Display for ContentTransformer {
 	}
 }
 
-/// TODO
+/// Transformer which replaces line termination characters with either unix
+/// style (`\n`) or windows style (`\r\b`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum LineTerminator {
-	/// TODO
+	/// Replaces all occurences of `\r\n` with `\n` (unix style).
 	Lf,
 
-	/// TODO
+	/// Replaces all occurences of `\n` with `\r\n` (windows style).
 	Crlf,
 }
 

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -48,8 +48,7 @@ impl Transform for LineTerminator {
 					.collect::<Vec<_>>();
 
 				for (offset, lf_idx) in lf_idxs.into_iter().enumerate() {
-					let lf_idx = lf_idx + offset;
-					content.insert(lf_idx, '\r');
+					content.insert(lf_idx + offset, '\r');
 				}
 
 				Ok(content)

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -9,7 +9,14 @@ pub trait Transform {
 }
 
 /// TODO
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ContentTransformer {
+	/// TODO
+	LineTerminator(LineTerminator),
+}
+
+/// TODO
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum LineTerminator {
 	/// TODO
 	Lf,

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -55,17 +55,17 @@ impl fmt::Display for ContentTransformer {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum LineTerminator {
 	/// Replaces all occurrences of `\r\n` with `\n` (unix style).
-	Lf,
+	LF,
 
 	/// Replaces all occurrences of `\n` with `\r\n` (windows style).
-	Crlf,
+	CRLF,
 }
 
 impl Transform for LineTerminator {
 	fn transform(&self, mut content: String) -> Result<String> {
 		match self {
-			Self::Lf => Ok(content.replace("\r\n", "\n")),
-			Self::Crlf => {
+			Self::LF => Ok(content.replace("\r\n", "\n")),
+			Self::CRLF => {
 				let lf_idxs = content.match_indices('\n');
 				let mut cr_idxs = content.match_indices('\r').peekable();
 
@@ -117,7 +117,7 @@ mod tests {
 		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r\\n";
 
 		assert_eq!(
-			LineTerminator::Lf.transform(String::from(CONTENT))?,
+			LineTerminator::LF.transform(String::from(CONTENT))?,
 			"Hello\nWorld\nHow\nare\nyou today?\r\r\nLast line\r\\n"
 		);
 
@@ -129,7 +129,7 @@ mod tests {
 		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r\\n";
 
 		assert_eq!(
-			LineTerminator::Crlf.transform(String::from(CONTENT))?,
+			LineTerminator::CRLF.transform(String::from(CONTENT))?,
 			"Hello\r\nWorld\r\nHow\r\nare\r\nyou today?\r\r\r\nLast line\r\\n"
 		);
 

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -114,11 +114,11 @@ mod tests {
 
 	#[test]
 	fn line_terminator_lf() -> Result<()> {
-		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r";
+		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r\\n";
 
 		assert_eq!(
 			LineTerminator::Lf.transform(String::from(CONTENT))?,
-			"Hello\nWorld\nHow\nare\nyou today?\r\r\nLast line\r"
+			"Hello\nWorld\nHow\nare\nyou today?\r\r\nLast line\r\\n"
 		);
 
 		Ok(())
@@ -126,11 +126,11 @@ mod tests {
 
 	#[test]
 	fn line_terminator_crlf() -> Result<()> {
-		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r";
+		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r\\n";
 
 		assert_eq!(
 			LineTerminator::Crlf.transform(String::from(CONTENT))?,
-			"Hello\r\nWorld\r\nHow\r\nare\r\nyou today?\r\r\r\nLast line\r"
+			"Hello\r\nWorld\r\nHow\r\nare\r\nyou today?\r\r\r\nLast line\r\\n"
 		);
 
 		Ok(())

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -1,4 +1,11 @@
-//! TODO
+//! Transforms run once for each defined dotile during the deploy process.
+//!
+//! They can either be specified for a whole profile, in which case each dotile
+//! is transformed by them or they can be attached to a specific dotile.
+//!
+//! The transformation takes place after the template resolving and takes the
+//! contents in a textual representation. After processing the text a new text
+//! must be returned.
 
 use std::fmt;
 

--- a/crates/punktf-lib/src/transform.rs
+++ b/crates/punktf-lib/src/transform.rs
@@ -1,0 +1,90 @@
+//! TODO
+
+use color_eyre::Result;
+
+/// TODO
+pub trait Transform {
+	/// TODO
+	fn transform(&self, content: String) -> Result<String>;
+}
+
+/// TODO
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineTerminator {
+	/// TODO
+	Lf,
+
+	/// TODO
+	Crlf,
+}
+
+impl Transform for LineTerminator {
+	fn transform(&self, mut content: String) -> Result<String> {
+		match self {
+			Self::Lf => Ok(content.replace("\r\n", "\n")),
+			Self::Crlf => {
+				let lf_idxs = content.match_indices('\n');
+				let mut cr_idxs = content.match_indices('\r').peekable();
+
+				// Allowed as it not needless here, the index iterator have a immutable ref
+				// and are still alive when the string gets modified. To "unborrow" the
+				// collect is necessary.
+				#[allow(clippy::needless_collect)]
+				let lf_idxs = lf_idxs
+					.filter_map(|(lf_idx, _)| {
+						while matches!(cr_idxs.peek(), Some((cr_idx,_)) if cr_idx + 1 < lf_idx) {
+							// pop standalone `\r`
+							let _ = cr_idxs.next().expect("Failed to advance peeked iterator");
+						}
+
+						if matches!(cr_idxs.peek(), Some((cr_idx, _)) if cr_idx + 1 == lf_idx) {
+							// pop matched cr_idx
+							let _ = cr_idxs.next().expect("Failed to advance peeked iterator");
+							None
+						} else {
+							Some(lf_idx)
+						}
+					})
+					.collect::<Vec<_>>();
+
+				for (offset, lf_idx) in lf_idxs.into_iter().enumerate() {
+					let lf_idx = lf_idx + offset;
+					content.insert(lf_idx, '\r');
+				}
+
+				Ok(content)
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use pretty_assertions::assert_eq;
+
+	use super::*;
+
+	#[test]
+	fn line_terminator_lf() -> Result<()> {
+		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r";
+
+		assert_eq!(
+			LineTerminator::Lf.transform(String::from(CONTENT))?,
+			"Hello\nWorld\nHow\nare\nyou today?\r\r\nLast line\r"
+		);
+
+		Ok(())
+	}
+
+	#[test]
+	fn line_terminator_crlf() -> Result<()> {
+		const CONTENT: &str = "Hello\r\nWorld\nHow\nare\r\nyou today?\r\r\r\nLast line\r";
+
+		assert_eq!(
+			LineTerminator::Crlf.transform(String::from(CONTENT))?,
+			"Hello\r\nWorld\r\nHow\r\nare\r\nyou today?\r\r\r\nLast line\r"
+		);
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
Transforms run once for each defined dotfile during the deploy process.

They can either be specified for a whole profile, in which case each dotfile is transformed by them or they can be attached to a specific dotfile.

A transform takes the contents of a dotfile, processes it and returns a new version of the content.

The contents are either a resolved template or a non-template dotfile.

# Order of execution

1) Content transformers specified in the profile
2) Content transformers specified in the specific dotfile

# Available Transformers

## LineTerminator

The `LineTerminator` transformer replaces all occurrences of one kind of line terminator with a other one.

### Options

- `LF` will replace all `\r\n` with a single `\n` (windows style -> unix style)
- `CRLF` will replace all `\n` with a `\r\n` (unix style -> windows style)

### Usage

Define the following in either the root of the profile or a specific dotfile:

```yaml
transformers:
  - LineTerminator: CRLF
```