### PR TITLE
Slimming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,19 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - staging
+      - trying
 
 name: CI
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings -W rust-2021-compatibility"
+  RUSTUP_MAX_RETRIES: 10
 
 jobs:
   test:
@@ -12,16 +25,25 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
-      - name: Run cargo test
+
+      - name: Compile
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --no-run --locked
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -- --nocapture --quiet
 
   lints:
     name: Lints
@@ -29,6 +51,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -36,11 +59,13 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v1
 
+      # `test` is used instead of `build` to also include the test modules in
+      # the compilation check.
       - name: Compile
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,6 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    env:
-      # Get backtraces on panics
-      RUST_BACKTRACE: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -32,6 +29,10 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+
+      # This pluging should be loaded after toolchain setup
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
 
       - name: Compile
         uses: actions-rs/cargo@v1
@@ -59,6 +60,10 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+
+      # This pluging should be loaded after toolchain setup
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +158,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
+ "humantime",
  "log",
+ "regex",
  "termcolor",
 ]
 
@@ -192,6 +203,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indenter"
@@ -375,6 +392,23 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,24 +114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
 dependencies = [
  "backtrace",
- "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
  "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -172,9 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime",
  "log",
- "regex",
  "termcolor",
 ]
 
@@ -217,12 +192,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indenter"
@@ -326,12 +295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
-
-[[package]]
 name = "pretty_assertions"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,23 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,15 +441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,68 +493,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ punktf-lib = { version = "1.0.0", path = "crates/punktf-lib" }
 
 [profile.dev]
 opt-level = 0
+# Only retain line level debug information; This will speed up the build process
+# and is only used when debugging.
+debug = 1
 
 [profile.dev.package.backtrace]
 # color-eyre: Improves performance for debug builds
@@ -44,3 +47,6 @@ opt-level = 3
 strip = true
 # Reduces parallel code generation units to increase optimizations
 codegen-units = 1
+# Dont retain any debug information; This will speed up the build process
+# and is only used when debugging.
+debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ opt-level = 3
 
 [profile.release]
 lto = "thin"
-opt-level = 3
+# Optimize for binary size. In this case also turns out to be the fastest to
+# compile.
+opt-level = "s"
 # Strip symbols for the release build to decrease binary size
 strip = true
 # Reduces parallel code generation units to increase optimizations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ path = "crates/punktf-cli/main.rs"
 name = "punktf"
 
 [workspace]
+# Use new resolver
+resolver = "2"
 members = [
 	"crates/punktf-lib"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,17 @@ members = [
 
 [dependencies]
 clap = "3.0.0-beta.4"
-color-eyre = "0.5.11"
-env_logger = "0.9.0"
+color-eyre = { version = "0.5.11", default-features = false }
+env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty"] }
 log = "0.4.14"
 punktf-lib = { version = "1.0.0", path = "crates/punktf-lib" }
 
 [profile.dev]
 opt-level = 0
+
+[profile.dev.package.backtrace]
+# color-eyre: Improves performance for debug builds
+opt-level = 3
 
 [profile.release]
 lto = "thin"

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ todos:
 	rg "(TODO|print(!|ln!)|unwrap\()"
 
 # Compile timings
-timings:
+timings: clean
 	cargo +nightly build -p punktf --bin punktf -Z timings --release

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+status = [
+	"Test Suite",
+	"Lints",
+]
+
+delete_merged_branches = true
+timeout_sec = 1200 # 20 min

--- a/crates/punktf-lib/Cargo.toml
+++ b/crates/punktf-lib/Cargo.toml
@@ -14,8 +14,7 @@ keywords = ["dotfiles", "cli", "dotfile", "dotfiles-manager", "templating"]
 name = "punktf_lib"
 
 [dependencies]
-color-eyre = "0.5.11"
-env_logger = "0.9.0"
+color-eyre = { version = "0.5.11", default-features = false }
 log = "0.4.14"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
@@ -27,3 +26,4 @@ cfg-if = "1.0.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"
+env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty"] }

--- a/crates/punktf-lib/Cargo.toml
+++ b/crates/punktf-lib/Cargo.toml
@@ -26,4 +26,8 @@ cfg-if = "1.0.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"
-env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty"] }
+env_logger = "0.9.0"
+
+[profile.dev.package.backtrace]
+# color-eyre: Improves performance for debug builds
+opt-level = 3

--- a/crates/punktf-lib/Cargo.toml
+++ b/crates/punktf-lib/Cargo.toml
@@ -27,7 +27,3 @@ cfg-if = "1.0.0"
 [dev-dependencies]
 pretty_assertions = "0.7.2"
 env_logger = "0.9.0"
-
-[profile.dev.package.backtrace]
-# color-eyre: Improves performance for debug builds
-opt-level = 3


### PR DESCRIPTION
This PR tries to reduce the compile time and also the final size of the binary.

The improvements will be realized  primarily by removing unnecessary dependencies and features.

The effort was triggered by reading <https://matklad.github.io/2021/09/04/fast-rust-builds.html>.

And while this may be overkill for this specific project, a reduction in binary size is always welcome.

## Changes

- `env_logger`: Removed features `serde`, `humantime`
- `color-eyre`: Removed features `track-caller`, `capture-spantrace`
- Moved dependency `env_logger` of `punktf-lib` to `dev-dependencies`
- Reduced/Removed debug information for builds
- Started using [new feature resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#features) 
- Updated ci workflow to allow caching of specific folder between runs

## Comparison

Build target: `nightly-x86_64-unknown-linux-gnu`
|                | Compile Time (s) | Size (B) | Performance (clock cycles<sup>[1](#fn1)</sup>) |
| -------------- | ---------------- | -------- | --------------------------- |
| **Before**     | 23.7             | 2248     | 8931525                     |
| **After**      | 19.3             | 1592     | 9395800                     |
| -----------    | -----            | -----    | -------                     |
| **Difference** | -19%             | -29%     | +5%                         |

<a name="fn1">1</a>: Measured for a medium sized profile and averaged over 2000 iterations. [`_rdtsc`](https://doc.rust-lang.org/core/arch/x86_64/fn._rdtsc.html) was used for getting the cycle count.