### PR TITLE
Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added informational message when running `deploy` with the `dry-run` flag ([#61](https://github.com/Shemnei/punktf/pull/61))
 - Added better error messages when profile parsing fails ([#62](https://github.com/Shemnei/punktf/pull/62))
 - Added better error messages when punktf source directory or subdirectories are missing ([#65](https://github.com/Shemnei/punktf/pull/65))
+- Yaml/Json Profiles are now seperate features and can be added/removed via the `Cargo.toml` of `punktf` ([#69](https://github.com/Shemnei/punktf/pull/69)). For available options see punktf-lib's [Cargo.toml](https://github.com/Shemnei/punktf/blob/main/crates/punktf-lib/Cargo.toml).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed release profile to decrease compile times and final binary size ([#60](https://github.com/Shemnei/punktf/pull/60))
 
+### Removed
+
+- Removed current directory as fallback for the `punktf` source directory when neither `-s/--source` or `PUNKTF_SOURCE` were supplied. This mainly caused confusion and was a undocumented feature.
+
 ## [1.0.1] - 2021-09-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added new if expression syntax `{{@if !{{VARIABLE}}}}` for templates ([#67](https://github.com/Shemnei/punktf/pull/67))
 - Added informational message when running `deploy` with the `dry-run` flag ([#61](https://github.com/Shemnei/punktf/pull/61))
+- Added better error messages when profile parsing fails ([#62](https://github.com/Shemnei/punktf/pull/62))
+- Added better error messages when punktf source directory or subdirectories are missing ([#65](https://github.com/Shemnei/punktf/pull/65))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added informational message when running `deploy` with the `dry-run` flag ([#61](https://github.com/Shemnei/punktf/pull/61))
 - Added better error messages when profile parsing fails ([#62](https://github.com/Shemnei/punktf/pull/62))
 - Added better error messages when punktf source directory or subdirectories are missing ([#65](https://github.com/Shemnei/punktf/pull/65))
-- Yaml/Json Profiles are now seperate features and can be added/removed via the `Cargo.toml` of `punktf` ([#69](https://github.com/Shemnei/punktf/pull/69)). For available options see punktf-lib's [Cargo.toml](https://github.com/Shemnei/punktf/blob/main/crates/punktf-lib/Cargo.toml).
+- Yaml/Json profiles are now separate features and can be added/removed via the `Cargo.toml` of `punktf` ([#69](https://github.com/Shemnei/punktf/pull/69)). For available options see punktf-lib's [Cargo.toml](https://github.com/Shemnei/punktf/blob/main/crates/punktf-lib/Cargo.toml).
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clap = "3.0.0-beta.4"
 color-eyre = { version = "0.5.11", default-features = false }
 env_logger = { version = "0.9.0", default-features = false, features = ["termcolor", "atty"] }
 log = "0.4.14"
-punktf-lib = { version = "1.0.0", path = "crates/punktf-lib" }
+punktf-lib = { version = "1.0.0", path = "crates/punktf-lib", features = ["profile-all"] }
 
 [profile.dev]
 opt-level = 0

--- a/crates/punktf-cli/main.rs
+++ b/crates/punktf-cli/main.rs
@@ -186,7 +186,7 @@ fn handle_commands(opts: opt::Opts) -> Result<()> {
 			target,
 			dry_run,
 		}) => {
-			let ptf_src = PunktfSource::from_root(source.into())?;
+			let ptf_src = PunktfSource::from_root(source)?;
 
 			let mut builder = LayeredProfile::build();
 

--- a/crates/punktf-cli/opt.rs
+++ b/crates/punktf-cli/opt.rs
@@ -5,59 +5,9 @@
 // what we want.
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
 
-use std::fmt;
-use std::ops::Deref;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use clap::{crate_authors, crate_description, crate_version, Clap};
-use color_eyre::Result;
-
-/// The path to `punktfs` source directory.
-///
-/// Used so that it defaults to [`std::env::current_dir`] if no value is given.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SourcePath(PathBuf);
-
-impl Default for SourcePath {
-	fn default() -> Self {
-		Self(std::env::current_dir().unwrap_or_else(|_| {
-			panic!(
-				"Failed to get `current_dir`. Please either use the `-s/--source` argument or the \
-				 environment variable `{}` to set the source directory.",
-				super::PUNKTF_SOURCE_ENVVAR
-			)
-		}))
-	}
-}
-
-impl fmt::Display for SourcePath {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		fmt::Display::fmt(&self.0.display(), f)
-	}
-}
-
-impl From<SourcePath> for PathBuf {
-	fn from(value: SourcePath) -> Self {
-		value.0
-	}
-}
-
-impl Deref for SourcePath {
-	type Target = PathBuf;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl FromStr for SourcePath {
-	type Err = std::convert::Infallible;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Ok(Self(PathBuf::from(s)))
-	}
-}
 
 #[derive(Debug, Clap)]
 #[clap(version = crate_version!(), author = crate_authors!(), about = crate_description!())]
@@ -72,8 +22,8 @@ pub struct Opts {
 #[derive(Debug, Clap)]
 pub struct Shared {
 	/// The source directory where the profiles and dotfiles are located.
-	#[clap(short, long, env = super::PUNKTF_SOURCE_ENVVAR, default_value_t)]
-	pub source: SourcePath,
+	#[clap(short, long, env = super::PUNKTF_SOURCE_ENVVAR)]
+	pub source: PathBuf,
 
 	/// Runs with specified level of verbosity which affects the log level.
 	///

--- a/crates/punktf-lib/Cargo.toml
+++ b/crates/punktf-lib/Cargo.toml
@@ -13,12 +13,18 @@ keywords = ["dotfiles", "cli", "dotfile", "dotfiles-manager", "templating"]
 [lib]
 name = "punktf_lib"
 
+[features]
+
+profile-all = ["profile-json", "profile-yaml"]
+profile-json = ["serde_json"]
+profile-yaml = ["serde_yaml"]
+
 [dependencies]
 color-eyre = { version = "0.5.11", default-features = false }
 log = "0.4.14"
 serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0.64"
-serde_yaml = "0.8.17"
+serde_json = { version = "1.0.64", optional = true }
+serde_yaml = { version = "0.8.17", optional = true }
 thiserror = "1.0.26"
 walkdir = "2.3.2"
 unicode-width = "0.1.8"

--- a/crates/punktf-lib/src/profile.rs
+++ b/crates/punktf-lib/src/profile.rs
@@ -95,16 +95,14 @@ impl Profile {
 	/// Tries to load a profile from a json file.
 	fn from_json_file(file: File) -> Result<Self> {
 		serde_json::from_reader(&file).map_err(|err| {
-			color_eyre::Report::msg(err)
-				.wrap_err(format!("Failed to parse profile from json content.",))
+			color_eyre::Report::msg(err).wrap_err("Failed to parse profile from json content.")
 		})
 	}
 
 	/// Tries to load a profile from a yaml file.
 	fn from_yaml_file(file: File) -> Result<Self> {
 		serde_yaml::from_reader(file).map_err(|err| {
-			color_eyre::Report::msg(err)
-				.wrap_err(format!("Failed to parse profile from yaml content.",))
+			color_eyre::Report::msg(err).wrap_err("Failed to parse profile from yaml content.")
 		})
 	}
 }


### PR DESCRIPTION
- Improve error messages
    - #65
    - #62 
- Remove confusing/unused features
    - Removed current directory as fallback for the `punktf` source directory when neither `-s/--source` or `PUNKTF_SOURCE` were supplied. This mainly caused confusion and was a undocumented feature.
- Moved json/yaml profile support into separate features to individual enable/disable them

# Improvements

## #65 

New message

```bash
Error:
   0: Failed to resolve punktf's source directory (path: /home/a)
   1: No such file or directory (os error 2)
```

## #62

New messages

```bash
Error:
   0: Failed to process profile at path `/home/demo/.config/punktf/profiles/demo.json`
   1: Failed to parse profile from json content.
   2: expected value at line 3 column 12
```

```bash
Error:
   0: Failed to process profile at path `/home/demo/.config/punktf/profiles/demo.yaml`
   1: Failed to parse profile from yaml content.
   2: variables: invalid type: sequence, expected struct Variables at line 7 column 3
```