### PR TITLE
Fixed verbosity to reflect verbose flag occurances

### DIFF
--- a/crates/punktf-cli/main.rs
+++ b/crates/punktf-cli/main.rs
@@ -157,8 +157,10 @@ fn main() -> Result<()> {
 	let opts = opt::Opts::parse();
 
 	let log_level = match opts.shared.verbose {
-		0 => log::Level::Info,
-		1 => log::Level::Debug,
+		// Default if no value for `verbose` is given
+		0 => log::Level::Warn,
+		1 => log::Level::Info,
+		2 => log::Level::Debug,
 		_ => log::Level::Trace,
 	};
 

--- a/crates/punktf-cli/opt.rs
+++ b/crates/punktf-cli/opt.rs
@@ -29,9 +29,9 @@ pub struct Shared {
 	///
 	/// The level can be set by repeating the flag `n` times (e.g. `-vv` for 2).
 	/// Levels:
-	///     0 - `Info`;
-	///     1 - `Debug`;
-	///     2 - `Trace`.
+	///     1 - `Info`;
+	///     2 - `Debug`;
+	///     3 - `Trace`.
 	#[clap(short, long, parse(from_occurrences))]
 	pub verbose: u8,
 }


### PR DESCRIPTION
Instead of `Info` being used if no `--verbose/-v` flag is given, the new default now is 'Warn'.
`Info` now requires one occurrence of the verbose flag.