### PR TITLE
feat: Alias overwrite_target to target

### DIFF
--- a/crates/punktf-lib/src/profile/dotfile.rs
+++ b/crates/punktf-lib/src/profile/dotfile.rs
@@ -30,7 +30,7 @@ pub struct Dotfile {
 
 	/// Alternative absolute deploy target path. This will be used instead of
 	/// [`Profile::target`](`crate::profile::Profile::target`) when deploying.
-	#[serde(skip_serializing_if = "Option::is_none", default)]
+	#[serde(alias = "target", skip_serializing_if = "Option::is_none", default)]
 	pub overwrite_target: Option<PathBuf>,
 
 	/// Priority of the dotfile. Dotfiles with higher priority as others are

--- a/examples/80_simple_complete/profiles/simple.yml
+++ b/examples/80_simple_complete/profiles/simple.yml
@@ -8,6 +8,14 @@ post_hooks:
 
 dotfiles:
   - path: "config"
+    # Obsolete, replaced with `target`
+    overwrite_target: "/custom_other/target"
+    template: false
+  - path: "config"
+    # New version of `overwrite_target`
+    target: "/custom_other/target"
+    template: false
+  - path: "config"
     rename: ".config"
     template: false
   - path: "zsh/zshrc"


### PR DESCRIPTION
Alias `dotfile.overwrite_target` with `dotfile.target` to be consistent and make it more intuitive.

Related to #158 