### PR TITLE
fix: Remove unused qualification and fix conditional compilation for wasm

### DIFF
--- a/crates/punktf-lib/src/template/resolve.rs
+++ b/crates/punktf-lib/src/template/resolve.rs
@@ -81,7 +81,7 @@ macro_rules! family {
 				"unix"
 			} else if #[cfg(target_os = "windows")] {
 				"windows"
-			} else if #[cfg(target_os = "wasm")] {
+			} else if #[cfg(target_family = "wasm")] {
 				"wasm"
 			} else {
 				"unknown"

--- a/crates/punktf-lib/src/visit/mod.rs
+++ b/crates/punktf-lib/src/visit/mod.rs
@@ -465,7 +465,7 @@ impl<'a> Walker<'a> {
 				paths,
 				dotfile,
 				#[allow(unused_qualifications)]
-				None::<std::io::Error>,
+				None::<io::Error>,
 				Some(context),
 			);
 		};


### PR DESCRIPTION
Since linting is set to deny unused_qualifications punktf will not compile unless std:: is removed from std::io::Error