### PR TITLE
chore(ci): Remove macos ci target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
         rust: ["stable", "beta"]
         include:
         - os: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
   examples:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
         rust: ["stable", "beta"]
         include:
         - os: ubuntu-latest


### PR DESCRIPTION
As we do not provide offical builds and it takes ages to complete this target was removed